### PR TITLE
feat: build against SPDK 22.01

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -294,6 +294,7 @@ fn main() {
         .allowlist_function("^nvmf_tgt_accept")
         .allowlist_function("^nvme_qpair_.*")
         .allowlist_function("^nvme_ctrlr_.*")
+        .allowlist_function("^nvme_transport_qpair_.*")
         .blocklist_type("^longfunc")
         .allowlist_type("^spdk_nvme_ns_flags")
         .allowlist_type("^spdk_nvme_registered_ctrlr.*")

--- a/helpers/nvme_helper.h
+++ b/helpers/nvme_helper.h
@@ -20,6 +20,3 @@ int
 spdk_bdev_nvme_admin_passthru_ro(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
 			      const struct spdk_nvme_cmd *cmd, void *buf, size_t nbytes,
 			      spdk_bdev_io_completion_cb cb, void *cb_arg);
-
-void
-nvme_qpair_abort_reqs(struct spdk_nvme_qpair *qpair, uint32_t dnr);


### PR DESCRIPTION
Add nvme_transport_qpair_* to allowlist_function as the abort process
has changed. Remove the declaration of nvme_qpair_abort_reqs() as that
is already covered by the allowlist_function of nvme_qpair_*.