### PR TITLE
fix: fix arm64 build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -135,6 +135,7 @@ fn configure_spdk() -> Result<LibraryConfig, Error> {
         "spdk_accel",
         "spdk_accel_ioat",
         "spdk_bdev_aio",
+    #[cfg(target_arch = "x86_64")]
         "spdk_bdev_crypto",
         "spdk_bdev_delay",
         "spdk_bdev_error",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ extern "C" {
         line: i32,
         func: *const c_char,
         format: *const c_char,
-        args: libspdk::__va_list,
+        args: libspdk::va_list,
     );
 
     /// TODO


### PR DESCRIPTION
Openebs/spdk now only build with crypto lib on x86_64[1].
And libspdk only has no __va_list but va_list for arm64.

[1] https://github.com/openebs/mayastor/blob/7a1397d31459114cb42bc069dcf62dd817c05feb/nix/pkgs/libspdk/default.nix#L82

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>

This PR is related to Mayastor arm64 support: https://github.com/openebs/mayastor/issues/1063