### PR TITLE
chore(spdk): updating to use spdk v22.05-rc1

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -154,7 +154,6 @@ fn configure_spdk() -> Result<LibraryConfig, Error> {
         "spdk_event_nbd",
         "spdk_event_scsi",
         "spdk_event_sock",
-        "spdk_event_vhost",
         "spdk_event_vmd",
         "spdk_nvmf",
     ])?;


### PR DESCRIPTION
Updating to SPDK 22.05. This is the most recent stable release.
Bolt io-engine requires this version for ENOSPC support in thin-provisioned logical volumes.