### PR TITLE
fix: get the correct location for fio include files

### DIFF
--- a/build_spdk.sh
+++ b/build_spdk.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # This script replicates the build of SPDK as its done by nix without setting
 # any specifics in terms of CPU. The purpose is to easily make changes to libspdk
 # locally and then recompile it and test it with mayastor.
@@ -14,7 +14,7 @@ pushd spdk || { echo "Can not find spdk directory"; exit; }
 	--with-uring \
 	--disable-unit-tests \
 	--disable-tests \
-	--with-fio=$(which fio | sed s';bin/fio;include;')
+	--with-fio=$(echo $NIX_CFLAGS_COMPILE | grep -o '/nix/store/[^ ]*fio[^ ]*-dev\/include' | head -n 1)
 
 make -j $(nproc)
 


### PR DESCRIPTION
This was broken after splitting fio into 2 output derivations.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>