### PR TITLE
fix(nvme): snapshot creation command opcode changed

### DIFF
--- a/src/nvme.rs
+++ b/src/nvme.rs
@@ -320,7 +320,7 @@ pub mod nvme_admin_opc {
     // pub const SET_FEATURES: u8 = 0x09;
     // pub const GET_FEATURES: u8 = 0x0a;
     // Vendor-specific
-    pub const CREATE_SNAPSHOT: u8 = 0xc0;
+    pub const CREATE_SNAPSHOT: u8 = 0xc1;
 }
 
 /// NVM command set opcodes, from nvme_spec.h


### PR DESCRIPTION
Since now NVMe replica creation has payload which needs to be transferred along with thew vendor specific command (currently 0xc0), we need to use a new opcode: 0xc1, since data direction for the command is encoded in the lowest 2 bits, and WRITE commands should be 0x01, so we have to adjust the opcode to 0xc1.