### PR TITLE
fix(channel_reconfig): don't reconfigure the non-IO nexus channel

### DIFF
--- a/src/io_channel.rs
+++ b/src/io_channel.rs
@@ -59,7 +59,7 @@ impl<ChannelData> IoChannel<ChannelData> {
     }
 
     /// TODO
-    fn thread_name(&self) -> &str {
+    pub fn thread_name(&self) -> &str {
         unsafe {
             std::ffi::CStr::from_ptr(spdk_thread_get_name(
                 self.inner.as_ref().thread,

--- a/src/io_device_traverse.rs
+++ b/src/io_device_traverse.rs
@@ -170,7 +170,10 @@ extern "C" fn inner_traverse_channel<ChannelData, Ctx>(
     let ctx = TraverseCtx::<ChannelData, Ctx>::from_iter(i);
     let mut chan = IoChannel::<ChannelData>::from_iter(i);
 
-    let rc = (ctx.channel_cb)(chan.channel_data_mut(), &mut ctx.ctx);
+    let mut rc = ChannelTraverseStatus::Ok;
+    if chan.thread_name() != "init_thread" {
+        rc = (ctx.channel_cb)(chan.channel_data_mut(), &mut ctx.ctx);
+    }
 
     unsafe {
         spdk_for_each_channel_continue(i, rc.into());


### PR DESCRIPTION
The sync qpair connect can race with a async connect during an unplug dynamic reconfiguration event. This can happen on the nexus channel that gets created as part of rebuild on spdk thread `init_thread`. Since this nexus channel is not used for normal IO, we can ignore this from reconfiguration. The rebuild IOs can still be served on this and the locked byte ranges will still be safe via other nexus channels, but any other child device add/remove will not disturb this channel via dynamic reconfigure path.