### PR TITLE
fix(nvme): fixing NvmeStatus wrapper representation

### DIFF
--- a/src/nvme.rs
+++ b/src/nvme.rs
@@ -64,6 +64,7 @@ impl spdk_nvme_status {
 
 /// Status code types.
 #[derive(Copy, Clone, Eq, PartialOrd, PartialEq)]
+#[repr(C)]
 pub enum NvmeStatus {
     /// Generic command status codes.
     /// Corresponds to `spdk_nvme_generic_command_status_code` grouping.


### PR DESCRIPTION
All enum passed to extern "C" functions must have C-compatible representation.