### PR TITLE
refactor(bdev/lock): add range lock trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,14 @@ pub use crate::{
     bdev::Bdev,
     bdev_async::{BdevAsyncCallContext, BdevStats},
     bdev_builder::BdevBuilder,
-    bdev_desc::{BdevDesc, BdevDescError, BdevEvent, LbaRange, LbaRangeLock},
+    bdev_desc::{
+        BdevDesc,
+        BdevDescError,
+        BdevEvent,
+        LbaRange,
+        LbaRangeLock,
+        LbaRangeLocker,
+    },
     bdev_io::BdevIo,
     bdev_iter::{BdevGlobalIter, BdevModuleIter},
     bdev_module::{


### PR DESCRIPTION
Makes the range locking an interface which can be implemented by different types.