### PR TITLE
Re-run spdk build when the rev is modified and missing cherry-pick

### DIFF
--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -84,8 +84,8 @@ let
   # Derivation attributes
   #
   spdk = rec {
-    rev = "e5f7aa4c8250fd517764f073637f956b78c323c2";
-    sha256 = "sha256-VqaX5LAuNg0bAPz76xz2EU0XXLoyCwqDlP6+XWE5o14=";
+    rev = "50b064f553970b0f352691530e80f19b8432f034";
+    sha256 = "sha256-fim71qqNjGtITeXfR7kWIRpBbI2iF47D0suny3mjcCQ=";
     pname = "libspdk${nameSuffix}";
     version = "24.05-${lib.substring 0 7 rev}";
     name = "${pname}-${version}";

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -83,23 +83,31 @@ let
   #
   # Derivation attributes
   #
-  drvAttrs = rec {
+  spdk = rec {
+    rev = "e5f7aa4c8250fd517764f073637f956b78c323c2";
+    sha256 = "sha256-VqaX5LAuNg0bAPz76xz2EU0XXLoyCwqDlP6+XWE5o14=";
     pname = "libspdk${nameSuffix}";
-    version = "24.05-e5f7aa4";
+    version = "24.05-${lib.substring 0 7 rev}";
+    name = "${pname}-${version}";
+  };
+  drvAttrs = rec {
+    pname = spdk.pname;
+    version = spdk.version;
 
     src = [
       (fetchFromGitHub {
-        name = pname;
+        # Note that this would only rebuild if the first 7 chars differ, but in practice should be fine
+        name = spdk.name;
         owner = "openebs";
         repo = "spdk";
-        rev = "e5f7aa4c8250fd517764f073637f956b78c323c2";
-        sha256 = "sha256-VqaX5LAuNg0bAPz76xz2EU0XXLoyCwqDlP6+XWE5o14=";
+        rev = spdk.rev;
+        sha256 = spdk.sha256;
         fetchSubmodules = true;
       })
       ../../../build_scripts
     ];
 
-    sourceRoot = pname;
+    sourceRoot = spdk.name;
 
     nativeBuildInputs = [
       cmake


### PR DESCRIPTION
    fix: update spdk with higher retry delay
    
    Pulls in missing cherry-pick from spdk.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: re-run spdk build when the rev is modified
    
    Ensure this by adding the first 7chars of rev to the github derivation name.
    In practice this should be fine.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
