### PR TITLE
fix: reenable `--without-uring-zns` spdk config

### DIFF
--- a/build_scripts/build_spdk.sh
+++ b/build_scripts/build_spdk.sh
@@ -44,6 +44,7 @@ export MSG_NC=$RESET_COLOR
 CONFIGURE_ARGS=(
     "--without-shared"
     "--with-uring"
+    "--without-uring-zns"
     "--without-nvme-cuse"
     "--without-fuse"
     "--disable-unit-tests"


### PR DESCRIPTION
Add back `--without-uring-zns` spdk config that was removed in 2578b4387a66 ("feat(bdev): add support for CSAL ftl bdev targets (#67)") for preparation on potential future spdk ftl features.

The uring-zns spdk feature caused errors in the `core` cargo test:
```
...
ERROR mayastor::spdk:bdev_uring.c:591] Unable to open file /tmp/disk3.img/queue/zoned. errno: 2
...
```

For now the uring-zns spdk feature is not necessary.