### PR TITLE
fix: nix-shell environment for building spdk on arm

### DIFF
--- a/.github/workflows/pr-code-lint.yaml
+++ b/.github/workflows/pr-code-lint.yaml
@@ -5,7 +5,10 @@ on:
     types: ['opened', 'edited', 'reopened', 'synchronize']
 jobs:
   rust-lint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [github-arm64-2c-8gb, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -31,7 +31,6 @@
 , libtool
 , liburing
 , libuuid
-, llvmPackages
 , meson
 , nasm
 , ncurses
@@ -69,6 +68,8 @@ let
         else
           "--without-fio";
 
+      # Only set crossPrefix if we're actually cross-compiling 
+      # (which we aren't, but let's keep the logic).
       crossPrefix =
         if targetPlatform.config != buildPlatform.config then
           "--crossPrefix=${targetPlatform.config}"
@@ -90,13 +91,13 @@ let
     version = "24.05-${lib.substring 0 7 rev}";
     name = "${pname}-${version}";
   };
+
   drvAttrs = rec {
     pname = spdk.pname;
     version = spdk.version;
 
     src = [
       (fetchFromGitHub {
-        # Note that this would only rebuild if the first 7 chars differ, but in practice should be fine
         name = spdk.name;
         owner = "openebs";
         repo = "spdk";
@@ -113,16 +114,13 @@ let
       cmake
       gcc
       help2man
-      llvmPackages.bintools
-      llvmPackages.clang
-      llvmPackages.libclang
       meson
       ninja
       pkg-config
       procps
       udev
       utillinux
-      (python3.withPackages (ps: with ps; [ pyelftools ]))
+      pkgs.python3Packages.pyelftools
     ] ++ extraBuildInputs;
 
     buildInputs = [
@@ -158,9 +156,7 @@ let
     enableParallelBuilding = true;
     hardeningDisable = [ "all" ];
 
-    #
-    # Phases.
-    #
+    # Our phases
     prePatch = ''
       pushd ..
       chmod -R u+w build_scripts
@@ -181,4 +177,4 @@ let
     '';
   };
 in
-llvmPackages.stdenv.mkDerivation drvAttrs
+pkgs.stdenv.mkDerivation drvAttrs

--- a/nix/shell/spdk.nix
+++ b/nix/shell/spdk.nix
@@ -18,6 +18,15 @@ let
     echo "FIO path        : $FIO"
   '';
 
+  # Determine the system architecture
+  system = builtins.currentSystem;
+
+  # Define CFLAGS based on the architecture
+  cflagsValue =
+    if system == "aarch64-linux"
+    then "-march=armv8-a+crypto"
+    else "-msse4";
+
   # spdk-path argument overrides spdk argument.
   spdkCfg = if spdk-path != null then "none" else spdk;
 
@@ -63,14 +72,14 @@ let
     };
 
     # Do not use Nix libspdk. User must provide SPDK.
-    # Build environment for development libspdk packahe is provided.
+    # Build environment for development libspdk package is provided.
     none = {
       drv = null;
 
       buildInputs = with pkgs; libspdk-dev.nativeBuildInputs ++ libspdk-dev.buildInputs;
 
       shellEnv = {
-        CFLAGS = "-msse4";
+        CFLAGS = cflagsValue;
         SPDK_RS_BUILD_USE_LOGS = "yes"; # Tells spdk-rs build.rs script to rerun when build_logs dir is updated.
       };
 


### PR DESCRIPTION
This PR documents the changes needed to get the ARM64 build working and running the example hello-world application. Here are some of the issues encountered along the way.

1. **Debugging the ARM Nix env**  
   - I spun up an `arm64` machine on Hetzner and debugged the install process step by step.  
   - First tried running `nix-shell` without SPDK and hit issues with `pyelf`. Replacing `python3.withPackages` with `pkgs.python3Packages.pyelftools` fixed that.

2. **Compiler Issues**  
   - The main problem in a manual build was the `-msse4` flag, which is for `x86` extended instruction sets and doesn’t work on ARM.  
   - I split the `nix-shell` compiler flags into configurable strings so we can set optimization flags per architecture.
   - Then, in the default `nix-shell` `spdk` configure and build, Clang was the default compiler, this led to SVE compilation issues. In the "no-spdk-installed" nix environment, I noticed I was getting success w/ GCC, so migrated the nix script to remove Clang and use GCC by default. I don't want to get presumptuous that this is the best solution, very open to feedback on this.

**Context**  
   - As mentioned in the parent OEP (https://github.com/openebs/openebs/issues/3817), the goal here is just to make ARM builds possible—not optimized.
   - I have also tested the new changes on an `amd64` system and everything went as expected. Not super familiar with what test suite I should be running. 

### Addresses  
- Fixes #71 

---

*Please let me know if you'd rather me focus on getting the OEP to implementable rather than starting to implement fixes!*