### PR TITLE
feat: cryto build enable

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -298,7 +298,7 @@ fn main() {
         .allowlist_function(".*.aio.*")
         .allowlist_function("^accel.*")
         .allowlist_function(".*.crypto_disk.*")
-        .allowlist_function(".*.crypto_opts")
+        .allowlist_function(".*.crypto_opts.*")
         .allowlist_function(".*.iscsi.*")
         .allowlist_function(".*.lock_lba_range")
         .allowlist_function(".*.lvol.*")

--- a/build.rs
+++ b/build.rs
@@ -150,6 +150,8 @@ fn configure_spdk() -> Result<LibraryConfig, Error> {
     spdk_lib.mark_system("uuid");
     spdk_lib.mark_system("rdmacm");
     spdk_lib.mark_system("ibverbs");
+    spdk_lib.mark_system("mlx5");
+    spdk_lib.mark_system("keyutils");
 
     spdk_lib.set_static_search(true);
 
@@ -294,7 +296,9 @@ fn main() {
         .header("wrapper.h")
         .formatter(bindgen::Formatter::Rustfmt)
         .allowlist_function(".*.aio.*")
+        .allowlist_function("^accel.*")
         .allowlist_function(".*.crypto_disk.*")
+        .allowlist_function(".*.crypto_opts")
         .allowlist_function(".*.iscsi.*")
         .allowlist_function(".*.lock_lba_range")
         .allowlist_function(".*.lvol.*")

--- a/build_scripts/build_spdk.sh
+++ b/build_scripts/build_spdk.sh
@@ -262,7 +262,7 @@ function cmd_configure() {
     msg_info "Target platform: $TARGET_PLATFORM"
     case $TARGET_PLATFORM in
         "x86_64-unknown-linux-gnu")
-            CONFIGURE_ARGS+=("--target-arch=nehalem" "--without-crypto")
+            CONFIGURE_ARGS+=("--target-arch=nehalem" "--with-crypto")
             ;;
         "aarch64-unknown-linux-gnu")
             CONFIGURE_ARGS+=(" --target-arch=armv8-a+crypto")

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -44,6 +44,7 @@
 , utillinux
 , zlib
 , rdma-core
+, keyutils
 }:
 let
   # Suffix for debug build name.
@@ -85,8 +86,8 @@ let
   # Derivation attributes
   #
   spdk = rec {
-    rev = "50b064f553970b0f352691530e80f19b8432f034";
-    sha256 = "sha256-fim71qqNjGtITeXfR7kWIRpBbI2iF47D0suny3mjcCQ=";
+    rev = "5ad4b3f7da32eb96543bf15df88cfd790dbd5307";
+    sha256 = "sha256-P3/rhhxNuNC3LJK7em+v5ES4aZsx0LSTHf8HcCaWk5Y=";
     pname = "libspdk${nameSuffix}";
     version = "24.05-${lib.substring 0 7 rev}";
     name = "${pname}-${version}";
@@ -143,6 +144,7 @@ let
       numactl
       openssl
       rdma-core
+      keyutils
       zlib
     ] ++ extraBuildInputs;
 

--- a/src/bdev.rs
+++ b/src/bdev.rs
@@ -17,7 +17,7 @@ use crate::{
         spdk_bdev_get_aliases, spdk_bdev_get_buf_align, spdk_bdev_get_by_name,
         spdk_bdev_has_write_cache, spdk_bdev_io_type_supported, spdk_bdev_module,
         spdk_bdev_module_release_bdev, spdk_bdev_register, spdk_bdev_unregister,
-        SPDK_BDEV_CLAIM_EXCL_WRITE, SPDK_BDEV_CLAIM_NONE,
+        vbdev_crypto_disk_get_base_bdev, SPDK_BDEV_CLAIM_EXCL_WRITE, SPDK_BDEV_CLAIM_NONE,
     },
     BdevIo, BdevModule, BdevOps, IoChannel, IoDevice, IoType, Thread, Uuid,
 };
@@ -69,6 +69,20 @@ where
     /// Returns the name of the module for thos Bdev.
     pub fn module_name(&self) -> &str {
         unsafe { (*self.as_inner_ref().module).name.as_str() }
+    }
+
+    /// Returns the bdev handle which is the base of `self` bdev here.
+    /// e.g self could be a crypto vbdev and base an aio bdev.
+    /// XXX: This must be called only by crypto vbdev today.
+    pub fn crypto_base_bdev(&self) -> Option<Self> {
+        let p = unsafe {
+            vbdev_crypto_disk_get_base_bdev(self.name().as_ptr() as *mut std::os::raw::c_char)
+        };
+        if p.is_null() {
+            None
+        } else {
+            Some(Self::from_inner_ptr(p))
+        }
     }
 
     /// TODO

--- a/wrapper.h
+++ b/wrapper.h
@@ -45,6 +45,8 @@
 #include <thread/thread_internal.h>
 #include <bdev/bdev_internal.h>
 #include <blob/blobstore.h>
+#include <spdk/accel_module.h>
+#include <accel/dpdk_cryptodev/accel_dpdk_cryptodev.h>
 
 #include "helpers/logwrapper.h"
 #include "helpers/nvme_helper.h"


### PR DESCRIPTION
This gets basic crypto build to be working with software accel module.
The ipsecMB package isn't enabled as part of this, which will be required for dpdk_cryptodev module. Will do that in subsequent change once issues with that are sorted.