### PR TITLE
chore: add rust-src to the shell

### DIFF
--- a/nix/shell/ci.nix
+++ b/nix/shell/ci.nix
@@ -7,9 +7,7 @@ let
   '';
 in
 {
-  buildInputs = with pkgs; [
-    pre-commit
-  ];
+  buildInputs = pkgs.lib.optional (usePreCommit) pre-commit;
 
   shellHook = ''
     if [ "${toString usePreCommit}" = "1" ]; then

--- a/nix/shell/rust.nix
+++ b/nix/shell/rust.nix
@@ -43,7 +43,7 @@ let
     # Stable Rust channel configuration.
     stable = {
       buildInputs = buildInputs ++ [
-        rustChannels.stable
+        (rustChannels.stable.override ({ extensions = [ "rust-src" ]; }))
       ];
 
       inherit shellEnv;
@@ -59,7 +59,7 @@ let
     # Nightly Rust channel configuration.
     nightly = {
       buildInputs = buildInputs ++ [
-        rustChannels.nightly
+        (rustChannels.nightly.override ({ extensions = [ "rust-src" ]; }))
       ];
 
       inherit shellEnv;
@@ -76,7 +76,7 @@ let
     # Rust's ASAN requires nightly Rust.
     asan = {
       buildInputs = buildInputs ++ [
-        rustChannels.nightly
+        (rustChannels.nightly.override ({ extensions = [ "rust-src" ]; }))
       ];
 
       shellEnv = shellEnv // {


### PR DESCRIPTION
This allows IDEs to navigate the rust standard library.