### PR TITLE
feat(raid0): add SPDK raid support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -130,7 +130,6 @@ fn configure_spdk() -> Result<LibraryConfig, Error> {
     spdk_lib.exclude_lib("spdk_bdev_blobfs");
     spdk_lib.exclude_lib("spdk_bdev_gpt");
     spdk_lib.exclude_lib("spdk_bdev_passthru");
-    spdk_lib.exclude_lib("spdk_bdev_raid");
     spdk_lib.exclude_lib("spdk_bdev_split");
     spdk_lib.exclude_lib("spdk_event_nvmf");
     spdk_lib.exclude_lib("spdk_sock_uring");
@@ -307,6 +306,7 @@ fn main() {
         .allowlist_function("^iscsi.*")
         .allowlist_function("^spdk.*")
         .allowlist_function("^.*malloc_disk")
+        .allowlist_function("^raid_bdev.*")
         .allowlist_function("^bdev.*")
         .allowlist_function("^nbd_.*")
         .allowlist_function("^vbdev_.*")

--- a/wrapper.h
+++ b/wrapper.h
@@ -9,6 +9,7 @@
 #include <bdev/nvme/bdev_nvme.h>
 #include <bdev/malloc/bdev_malloc.h>
 #include <bdev/null/bdev_null.h>
+#include <bdev/raid/bdev_raid.h>
 #include <bdev/uring/bdev_uring.h>
 #include <iscsi/init_grp.h>
 #include <iscsi/iscsi.h>


### PR DESCRIPTION
Add SPDK based raid module to spdk-rs.

This change is required for oep(4011)