### PR TITLE
fix: add missing enum for SPDK_BDEV_IO_TYPE_NVME_IOV_MD

### DIFF
--- a/src/io_type.rs
+++ b/src/io_type.rs
@@ -25,6 +25,7 @@ pub enum IoType {
     SeekHole = libspdk::SPDK_BDEV_IO_TYPE_SEEK_HOLE,
     SeekData = libspdk::SPDK_BDEV_IO_TYPE_SEEK_DATA,
     Copy = libspdk::SPDK_BDEV_IO_TYPE_COPY,
+    NvmeIovMd = libspdk::SPDK_BDEV_IO_TYPE_NVME_IOV_MD,
     IoNumTypes = libspdk::SPDK_BDEV_NUM_IO_TYPES,
 }
 


### PR DESCRIPTION
It seems that when the key does not match the value, there's a runtime error, rather than at compile time.