### PR TITLE
fix: pull lvs unload fixes from spdk

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,6 +3,12 @@ queue_rules:
     update_method: rebase
     branch_protection_injection_mode: merge
     update_bot_account: openebs-ci
+    merge_conditions:
+      - check-success = code-lint
+      - check-success = commitlint
+    queue_conditions:
+      - check-success = code-lint
+      - check-success = commitlint
 merge_queue:
   max_parallel_checks: 1
 pull_request_rules:

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -79,3 +79,15 @@ jobs:
           nix_path: ${{ env.NIX_PATH }}
       - name: nix-shell
         run: nix-shell --pure -p nixpkgs-fmt --run "nixpkgs-fmt --check ."
+
+  code-lint:
+    if: always()
+    needs:
+      - rust-lint
+      - rust-dev
+      - nix-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -92,8 +92,8 @@ let
   # Derivation attributes
   #
   spdk = rec {
-    rev = "e1aa16a365c6e7f3fe64541f1159aa3c2b4c055d";
-    sha256 = "sha256-Sqz7Z5TF5mS4mXknolN4VMGy9uMyrrw+4Sl8zt6XLpA=";
+    rev = "24775a47ebf16c066cea47e7da98bed2e4d1d798";
+    sha256 = "sha256-4FkDgIgnuETHZSwmz0SzvKju71NcD6aCmJYnh9OuBsM=";
     pname = "libspdk${nameSuffix}";
     version = "25.05-${lib.substring 0 7 rev}";
     name = "${pname}-${version}";

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -92,8 +92,8 @@ let
   # Derivation attributes
   #
   spdk = rec {
-    rev = "b78cde6f5cdd2f0f50810743d2865d7bee825ce4";
-    sha256 = "sha256-GVWrKeYsKpro1XMYblky7ik6qw07aa/4CZqb9JU5cQU=";
+    rev = "e1aa16a365c6e7f3fe64541f1159aa3c2b4c055d";
+    sha256 = "sha256-Sqz7Z5TF5mS4mXknolN4VMGy9uMyrrw+4Sl8zt6XLpA=";
     pname = "libspdk${nameSuffix}";
     version = "25.05-${lib.substring 0 7 rev}";
     name = "${pname}-${version}";


### PR DESCRIPTION
    build: pull all aio/uring patches from upstream
    
    Pulls all the error patches which trigger hot-removal.

---

    ci(mergify): ensure jobs are passed
    
    Adds collection result for lint runs
    Add these to mergify to ensure we always merge green
    
---

    build: pull in lvs unload spdk fix
    
    Also include memory fix for blobstore reload.
