### PR TITLE
feat(thread): add interrupt mode and FdGroup API wrappers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -338,6 +338,7 @@ fn main() {
         .rustified_enum("spdk_nvme_path_status_code")
         .allowlist_type("spdk_ftl_mode")
         .rustified_enum("spdk_ftl_mode")
+        .allowlist_type("spdk_fd_type")
         .blocklist_type("spdk_bdev_io_error_stat")
         .allowlist_var("^NVMF.*")
         .allowlist_var("^SPDK.*")

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -92,8 +92,8 @@ let
   # Derivation attributes
   #
   spdk = rec {
-    rev = "54528416ba1de5efbf21dfd084a4f616445bac1b";
-    sha256 = "sha256-OmmPwb6rAttdA4KozouPmphLCl9///z16IW+zyceP50=";
+    rev = "8c3189eaa28fbae79df297d692188bf0ccfa1470";
+    sha256 = "sha256-9QUpeYS3mjgbjPfSyzx3dklEolEkU5w39R4vEE8frII=";
     pname = "libspdk${nameSuffix}";
     version = "25.05-${lib.substring 0 7 rev}";
     name = "${pname}-${version}";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use crate::{
     },
     nvmf::{NvmfController, NvmfSubsystemEvent},
     poller::{Poller, PollerBuilder},
-    thread::{CurrentThreadGuard, FdGroup, Thread, FD_TYPE_EVENTFD},
+    thread::{CurrentThreadGuard, FdGroup, Thread},
     unsafe_types::{UnsafeData, UnsafeRef},
     untyped_bdev::UntypedBdev,
     uuid::Uuid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use crate::{
     },
     nvmf::{NvmfController, NvmfSubsystemEvent},
     poller::{Poller, PollerBuilder},
-    thread::{CurrentThreadGuard, Thread},
+    thread::{CurrentThreadGuard, FdGroup, Thread, FD_TYPE_EVENTFD},
     unsafe_types::{UnsafeData, UnsafeRef},
     untyped_bdev::UntypedBdev,
     uuid::Uuid,

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -359,8 +359,6 @@ pub const FD_TYPE_EVENTFD: u32 = 0x1;
 /// implementing SPDK's interrupt-driven reactor pattern.
 pub struct FdGroup {
     inner: NonNull<spdk_fd_group>,
-    /// Whether this FdGroup owns the underlying pointer (should destroy on drop).
-    owned: bool,
 }
 
 impl Debug for FdGroup {
@@ -381,7 +379,6 @@ impl FdGroup {
         }
         Ok(Self {
             inner: NonNull::new(ptr).expect("spdk_fd_group_create returned null"),
-            owned: true,
         })
     }
 
@@ -479,9 +476,7 @@ impl FdGroup {
 
 impl Drop for FdGroup {
     fn drop(&mut self) {
-        if self.owned {
-            unsafe { spdk_fd_group_destroy(self.as_ptr()) };
-        }
+        unsafe { spdk_fd_group_destroy(self.as_ptr()) };
     }
 }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -347,11 +347,6 @@ impl Thread {
     }
 }
 
-/// fd_type value for eventfds: `fd_group_wait()` auto-drains these
-/// by reading the counter to 0 before invoking the callback.
-/// Matches `SPDK_FD_TYPE_EVENTFD` in `spdk/fd_group.h`.
-pub const FD_TYPE_EVENTFD: u32 = 0x1;
-
 /// Wrapper for `spdk_fd_group` -- an event multiplexing group that
 /// aggregates file descriptors and supports hierarchical nesting.
 ///

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -10,9 +10,14 @@ use std::{
 use crate::{
     cpu_cores::{Cores, CpuMask},
     libspdk::{
-        spdk_get_thread, spdk_set_thread, spdk_thread, spdk_thread_create, spdk_thread_destroy,
-        spdk_thread_exit, spdk_thread_get_by_id, spdk_thread_get_id, spdk_thread_get_name,
-        spdk_thread_is_exited, spdk_thread_poll, spdk_thread_send_msg,
+        spdk_event_handler_opts, spdk_fd_group, spdk_fd_group_add, spdk_fd_group_add_ext,
+        spdk_fd_group_create, spdk_fd_group_destroy, spdk_fd_group_get_default_event_handler_opts,
+        spdk_fd_group_nest, spdk_fd_group_unnest, spdk_fd_group_wait, spdk_get_thread,
+        spdk_interrupt_mode_enable, spdk_interrupt_mode_is_enabled, spdk_set_thread, spdk_thread,
+        spdk_thread_create, spdk_thread_destroy, spdk_thread_exit, spdk_thread_get_by_id,
+        spdk_thread_get_id, spdk_thread_get_interrupt_fd, spdk_thread_get_interrupt_fd_group,
+        spdk_thread_get_name, spdk_thread_is_exited, spdk_thread_poll, spdk_thread_send_msg,
+        spdk_thread_set_interrupt_mode,
     },
 };
 
@@ -157,6 +162,43 @@ impl Thread {
         let _ = unsafe { spdk_thread_poll(self.as_ptr(), 0, 0) };
     }
 
+    /// Switch the current SPDK thread between poll mode and interrupt mode.
+    ///
+    /// In interrupt mode, the thread's pollers are driven by epoll events
+    /// instead of busy-polling, dramatically reducing CPU usage when idle.
+    ///
+    /// # Safety
+    /// Must be called from within the context of this SPDK thread
+    /// (i.e., this thread must be set as the current thread).
+    /// `interrupt_mode_enable()` must have been called during init.
+    pub fn set_interrupt_mode(enable: bool) {
+        unsafe { spdk_thread_set_interrupt_mode(enable) }
+    }
+
+    /// Get the interrupt fd (epoll fd) for this thread.
+    ///
+    /// Returns the file descriptor that becomes ready when any of the
+    /// thread's interrupt file descriptors have events. Only meaningful
+    /// when the thread is in interrupt mode.
+    pub fn get_interrupt_fd(&self) -> i32 {
+        unsafe { spdk_thread_get_interrupt_fd(self.as_ptr()) }
+    }
+
+    /// Enable SPDK interrupt mode globally.
+    ///
+    /// Must be called once during initialization before any thread
+    /// can use `set_interrupt_mode()`.
+    ///
+    /// Returns 0 on success or -errno on failure.
+    pub fn interrupt_mode_enable() -> i32 {
+        unsafe { spdk_interrupt_mode_enable() }
+    }
+
+    /// Check if SPDK interrupt mode is globally enabled.
+    pub fn interrupt_mode_is_enabled() -> bool {
+        unsafe { spdk_interrupt_mode_is_enabled() }
+    }
+
     /// TODO
     #[inline]
     pub fn set_current(&self) {
@@ -286,6 +328,151 @@ impl Thread {
             None => {
                 format!("Non-SPDK thread [core {}]", Cores::current())
             }
+        }
+    }
+
+    /// Get the interrupt fd_group for this thread.
+    ///
+    /// Returns a raw pointer to the thread's `spdk_fd_group`, which can
+    /// be nested into a reactor-level fd_group for hierarchical event
+    /// multiplexing. Only meaningful when interrupt mode is enabled.
+    pub fn get_interrupt_fd_group(&self) -> *mut spdk_fd_group {
+        unsafe { spdk_thread_get_interrupt_fd_group(self.as_ptr()) }
+    }
+}
+
+/// fd_type value for eventfds: `fd_group_wait()` auto-drains these
+/// by reading the counter to 0 before invoking the callback.
+/// Matches `SPDK_FD_TYPE_EVENTFD` in `spdk/fd_group.h`.
+pub const FD_TYPE_EVENTFD: u32 = 0x1;
+
+/// Wrapper for `spdk_fd_group` -- an event multiplexing group that
+/// aggregates file descriptors and supports hierarchical nesting.
+///
+/// Used by reactors to block until any nested thread has events,
+/// implementing SPDK's interrupt-driven reactor pattern.
+pub struct FdGroup {
+    inner: NonNull<spdk_fd_group>,
+    /// Whether this FdGroup owns the underlying pointer (should destroy on drop).
+    owned: bool,
+}
+
+impl Debug for FdGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FdGroup({:p})", self.inner)
+    }
+}
+
+unsafe impl Send for FdGroup {}
+
+impl FdGroup {
+    /// Create a new fd_group.
+    pub fn create() -> Result<Self, i32> {
+        let mut ptr: *mut spdk_fd_group = std::ptr::null_mut();
+        let rc = unsafe { spdk_fd_group_create(&mut ptr) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(Self {
+            inner: NonNull::new(ptr).expect("spdk_fd_group_create returned null"),
+            owned: true,
+        })
+    }
+
+    /// Add a file descriptor to this fd_group with a callback.
+    ///
+    /// When `efd` becomes readable, `fn_` is called with `arg`.
+    pub fn add(
+        &self,
+        efd: i32,
+        fn_: unsafe extern "C" fn(*mut c_void) -> i32,
+        arg: *mut c_void,
+    ) -> Result<(), i32> {
+        let rc = unsafe { spdk_fd_group_add(self.as_ptr(), efd, Some(fn_), arg, std::ptr::null()) };
+        if rc != 0 {
+            Err(rc)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Add a file descriptor with an explicit `fd_type`.
+    ///
+    /// Use `FD_TYPE_EVENTFD` for eventfds so that `fd_group_wait()`
+    /// automatically drains them (reads the counter to 0) before
+    /// calling the callback. Without this, level-triggered epoll
+    /// returns the fd on every call, causing a busy-spin.
+    pub fn add_with_fd_type(
+        &self,
+        efd: i32,
+        fn_: unsafe extern "C" fn(*mut c_void) -> i32,
+        arg: *mut c_void,
+        fd_type: u32,
+    ) -> Result<(), i32> {
+        let mut opts: spdk_event_handler_opts = unsafe { std::mem::zeroed() };
+        unsafe {
+            spdk_fd_group_get_default_event_handler_opts(
+                &mut opts,
+                std::mem::size_of::<spdk_event_handler_opts>() as u64,
+            );
+        }
+        opts.fd_type = fd_type;
+        let rc = unsafe {
+            spdk_fd_group_add_ext(
+                self.as_ptr(),
+                efd,
+                Some(fn_),
+                arg,
+                std::ptr::null(),
+                &mut opts,
+            )
+        };
+        if rc != 0 {
+            Err(rc)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Wait for events on the fd_group.
+    ///
+    /// `timeout` is in milliseconds. -1 blocks forever, 0 is non-blocking.
+    /// Returns the number of events processed.
+    pub fn wait(&self, timeout: i32) -> i32 {
+        unsafe { spdk_fd_group_wait(self.as_ptr(), timeout) }
+    }
+
+    /// Nest a child fd_group (typically a thread's fd_group) into this
+    /// parent fd_group. Events on the child will wake the parent's wait.
+    pub fn nest(&self, child: *mut spdk_fd_group) -> Result<(), i32> {
+        let rc = unsafe { spdk_fd_group_nest(self.as_ptr(), child) };
+        if rc != 0 {
+            Err(rc)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Remove a previously nested child fd_group.
+    pub fn unnest(&self, child: *mut spdk_fd_group) -> Result<(), i32> {
+        let rc = unsafe { spdk_fd_group_unnest(self.as_ptr(), child) };
+        if rc != 0 {
+            Err(rc)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns the raw pointer to the underlying `spdk_fd_group`.
+    pub fn as_ptr(&self) -> *mut spdk_fd_group {
+        self.inner.as_ptr()
+    }
+}
+
+impl Drop for FdGroup {
+    fn drop(&mut self) {
+        if self.owned {
+            unsafe { spdk_fd_group_destroy(self.as_ptr()) };
         }
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -189,9 +189,15 @@ impl Thread {
     /// Must be called once during initialization before any thread
     /// can use `set_interrupt_mode()`.
     ///
-    /// Returns 0 on success or -errno on failure.
-    pub fn interrupt_mode_enable() -> i32 {
-        unsafe { spdk_interrupt_mode_enable() }
+    /// Returns `Ok(())` on success. Must be called before
+    /// `spdk_thread_lib_init_ext()`.
+    pub fn interrupt_mode_enable() -> Result<(), Errno> {
+        let rc = unsafe { spdk_interrupt_mode_enable() };
+        if rc != 0 {
+            Err(Errno::from_raw(rc.abs()))
+        } else {
+            Ok(())
+        }
     }
 
     /// Check if SPDK interrupt mode is globally enabled.
@@ -367,11 +373,11 @@ unsafe impl Send for FdGroup {}
 
 impl FdGroup {
     /// Create a new fd_group.
-    pub fn create() -> Result<Self, i32> {
+    pub fn create() -> Result<Self, Errno> {
         let mut ptr: *mut spdk_fd_group = std::ptr::null_mut();
         let rc = unsafe { spdk_fd_group_create(&mut ptr) };
         if rc != 0 {
-            return Err(rc);
+            return Err(Errno::from_raw(rc.abs()));
         }
         Ok(Self {
             inner: NonNull::new(ptr).expect("spdk_fd_group_create returned null"),
@@ -387,10 +393,10 @@ impl FdGroup {
         efd: i32,
         fn_: unsafe extern "C" fn(*mut c_void) -> i32,
         arg: *mut c_void,
-    ) -> Result<(), i32> {
+    ) -> Result<(), Errno> {
         let rc = unsafe { spdk_fd_group_add(self.as_ptr(), efd, Some(fn_), arg, std::ptr::null()) };
         if rc != 0 {
-            Err(rc)
+            Err(Errno::from_raw(rc.abs()))
         } else {
             Ok(())
         }
@@ -408,7 +414,7 @@ impl FdGroup {
         fn_: unsafe extern "C" fn(*mut c_void) -> i32,
         arg: *mut c_void,
         fd_type: u32,
-    ) -> Result<(), i32> {
+    ) -> Result<(), Errno> {
         let mut opts: spdk_event_handler_opts = unsafe { std::mem::zeroed() };
         unsafe {
             spdk_fd_group_get_default_event_handler_opts(
@@ -428,7 +434,7 @@ impl FdGroup {
             )
         };
         if rc != 0 {
-            Err(rc)
+            Err(Errno::from_raw(rc.abs()))
         } else {
             Ok(())
         }
@@ -437,27 +443,29 @@ impl FdGroup {
     /// Wait for events on the fd_group.
     ///
     /// `timeout` is in milliseconds. -1 blocks forever, 0 is non-blocking.
-    /// Returns the number of events processed.
+    /// Returns the number of events processed on success, or a negative
+    /// `-errno` on failure. Kept as raw `i32` (not `Result<_, Errno>`)
+    /// because the non-error path carries a count, not unit.
     pub fn wait(&self, timeout: i32) -> i32 {
         unsafe { spdk_fd_group_wait(self.as_ptr(), timeout) }
     }
 
     /// Nest a child fd_group (typically a thread's fd_group) into this
     /// parent fd_group. Events on the child will wake the parent's wait.
-    pub fn nest(&self, child: *mut spdk_fd_group) -> Result<(), i32> {
+    pub fn nest(&self, child: *mut spdk_fd_group) -> Result<(), Errno> {
         let rc = unsafe { spdk_fd_group_nest(self.as_ptr(), child) };
         if rc != 0 {
-            Err(rc)
+            Err(Errno::from_raw(rc.abs()))
         } else {
             Ok(())
         }
     }
 
     /// Remove a previously nested child fd_group.
-    pub fn unnest(&self, child: *mut spdk_fd_group) -> Result<(), i32> {
+    pub fn unnest(&self, child: *mut spdk_fd_group) -> Result<(), Errno> {
         let rc = unsafe { spdk_fd_group_unnest(self.as_ptr(), child) };
         if rc != 0 {
-            Err(rc)
+            Err(Errno::from_raw(rc.abs()))
         } else {
             Ok(())
         }

--- a/wrapper.h
+++ b/wrapper.h
@@ -21,6 +21,7 @@
 #include <spdk/cpuset.h>
 #include <spdk/crc32.h>
 #include <spdk/env.h>
+#include <spdk/fd_group.h>
 #include <spdk/env_dpdk.h>
 #include <spdk/event.h>
 #include <spdk/jsonrpc.h>


### PR DESCRIPTION
## Summary

Safe Rust wrappers for SPDK's interrupt mode facility and fd_group
hierarchical event multiplexing API (available since SPDK 24.09),
enabling custom reactors to sleep in `fd_group_wait()` instead of
busy-polling.

**New Thread methods:**
- `interrupt_mode_enable()` / `interrupt_mode_is_enabled()`: global init and query
- `set_interrupt_mode(enable)`: per-thread poll/interrupt switching
- `get_interrupt_fd()` / `get_interrupt_fd_group()`: access thread event fds

**New FdGroup struct** with RAII lifecycle:
- `create()` / `Drop`: lifecycle management
- `wait(timeout)`: block until events (`fd_group_wait`)
- `nest(child)` / `unnest(child)`: hierarchical event multiplexing
- `add()` / `add_with_fd_type()`: fd registration with optional auto-drain

**New constant:**
- `FD_TYPE_EVENTFD`: marks eventfds for auto-draining in `fd_group_wait()`

These APIs enable the mayastor reactor to implement interrupt mode,
reducing CPU from ~1000m per core to <300m when idle.

Depends-On: openebs/spdk#70 (iSCSI + bdev interrupt fixes)
Ref: openebs/mayastor#1745

## Test plan

- [x] Builds cleanly with updated libspdk
- [x] Used by mayastor reactor interrupt mode (73/86 pytest tests pass)
- [x] Production validated on 3-node cluster (16 volumes, 10+ days)
- [x] No regressions in poll mode