### PR TITLE
spdk: increase max lcores to 256

### DIFF
--- a/build_scripts/build_spdk.sh
+++ b/build_scripts/build_spdk.sh
@@ -51,6 +51,7 @@ CONFIGURE_ARGS=(
     "--disable-tests"
     "--with-rdma"
     "--with-crypto"
+    "--max-lcores=256"
 )
 
 MAKE_DEFAULT_ARGS="-j"                              # Default args for invoking GNU make


### PR DESCRIPTION
Added max_lcores in config script, now io-engine can be scheduled MSB > 128