### PR TITLE
fix(thread): add thread affinity restoration helper

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -291,19 +291,42 @@ impl Thread {
 
     /// TODO
     pub fn unaffinitize() {
+        Self::unaffinitize_tid(0);
+
+        unsafe {
+            trace!("pthread started on core {}", libc::sched_getcpu());
+        }
+    }
+
+    pub fn unaffinitize_tid(tid: libc::pid_t) {
         unsafe {
             let mut set: libc::cpu_set_t = std::mem::zeroed();
-            for i in 0..libc::sysconf(libc::_SC_NPROCESSORS_ONLN) {
-                libc::CPU_SET(i as usize, &mut set)
+
+            // Seed the mask from the thread's current allowed set. Under a
+            // cpuset cgroup this is the container's cpuset.cpus, i.e. the cores
+            // that belong to this workload. Using every online CPU here would
+            // let workers spill onto CPUs reserved for other workloads (other
+            // Guaranteed pods' dedicatedCpus, foreign isolcpus), which the
+            // kernel then never migrates them off.
+            if libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut set) != 0 {
+                // Fallback: all online CPUs.
+                for i in 0..libc::sysconf(libc::_SC_NPROCESSORS_ONLN) {
+                    libc::CPU_SET(i as usize, &mut set);
+                }
             }
 
-            Cores::count()
-                .into_iter()
-                .for_each(|i| libc::CPU_CLR(i as usize, &mut set));
+            // Keep workers off our reactor cores.
+            Cores::count().into_iter().for_each(|i| {
+                libc::CPU_CLR(i as usize, &mut set);
+            });
 
-            libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set);
+            // Never pin to an empty set (e.g. cpuset == reactor cores only);
+            // fall back to the original allowed set in that case.
+            if libc::CPU_COUNT(&set) == 0 {
+                libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut set);
+            }
 
-            trace!("pthread started on core {}", libc::sched_getcpu());
+            libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &set);
         }
     }
 


### PR DESCRIPTION
Kubernetes CPU Manager running with cpuManagerPolicy=static
may rewrite container cpusets when Guaranteed pods are
admitted or removed.

When cpuset.cpus.effective is updated, the kernel resets
task affinity masks for threads in the cgroup. This causes
Mayastor reactor threads to lose their CPU pinning and
Tokio worker threads to lose their unaffinitized CPU mask.

Add a cpuset monitor that watches for cpuset updates and
automatically restores reactor affinity. Tokio worker TIDs
are tracked so worker unaffinity can also be re-applied,
preserving separation between reactor and runtime threads.

This improves support for deployments using:
- cpuManagerPolicy=static
- isolcpus
- KubeVirt dedicated CPUs

Fixes silent affinity loss after Guaranteed pod
admission/removal events.