### PR TITLE
feat(nvme): enable Get Log Page 0x02 (SMART/Health) admin opcode

### DIFF
--- a/src/nvme.rs
+++ b/src/nvme.rs
@@ -188,7 +188,7 @@ impl From<*const spdk_nvme_cpl> for NvmeStatus {
 
 /// NVMe Admin opcode, from nvme_spec.h
 pub mod nvme_admin_opc {
-    // pub const GET_LOG_PAGE: u8 = 0x02;
+    pub const GET_LOG_PAGE: u8 = 0x02;
     pub const IDENTIFY: u8 = 0x06;
     // pub const ABORT: u8 = 0x08;
     // pub const SET_FEATURES: u8 = 0x09;


### PR DESCRIPTION
Uncomment the GET_LOG_PAGE=0x02 NVMe admin log identifier so the health log page can be requested through the existing bdev NVMe admin passthru path. Required by io-engine to read SMART/Health from VFIO-bound (pcie://) NVMe controllers that have no /dev node.