### PR TITLE
chore(libspdk): bump SPDK for async aio/uring unmap

### DIFF
--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -92,8 +92,8 @@ let
   # Derivation attributes
   #
   spdk = rec {
-    rev = "2b229ed46ab068d15bb492a68ab43fc80575d93e";
-    sha256 = "sha256-R4+TFdTJR6PlDrTAyg/apRUu/u5Us8fOZec9so9FUwk=";
+    rev = "652eab219053d952e46efb5fdfbb63f35ec1063d";
+    sha256 = "sha256-dOWtVtafTBmDtAOQRaLrcpEbNHZLZDjZjTKj7wF++uQ=";
     pname = "libspdk${nameSuffix}";
     version = "25.05-${lib.substring 0 7 rev}";
     name = "${pname}-${version}";

--- a/nix/pkgs/libspdk/default.nix
+++ b/nix/pkgs/libspdk/default.nix
@@ -92,8 +92,8 @@ let
   # Derivation attributes
   #
   spdk = rec {
-    rev = "bc57f3ea7933b0965c09e9d751c21a3968c6cc11";
-    sha256 = "sha256-BCQtK0dSVqHFUhX/lKCi9+nne6BtHuj25YsKQxuBUbo=";
+    rev = "2b229ed46ab068d15bb492a68ab43fc80575d93e";
+    sha256 = "sha256-R4+TFdTJR6PlDrTAyg/apRUu/u5Us8fOZec9so9FUwk=";
     pname = "libspdk${nameSuffix}";
     version = "25.05-${lib.substring 0 7 rev}";
     name = "${pname}-${version}";


### PR DESCRIPTION
Advances the pinned libspdk source to the openebs/spdk commit carrying the
async aio/uring UNMAP and WRITE_ZEROES work (nix/pkgs/libspdk/default.nix rev
and sha256 only; no code changes). The sha256 was computed with
nix-prefetch-github --fetch-submodules against the pinned rev.

Depends on the openebs/spdk PR for that work; the pin should be updated to its
merge commit before this merges. The Mayastor consumer PR then bumps its
spdk-rs submodule to this commit.

Validated by a full libspdk build from the new pin plus an io-engine
cargo build and clippy against it (0 errors).

Refs: openebs/openebs#4074
