### PR TITLE
fix(thread): seed the worker mask from the cpuset, not the caller

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -302,13 +302,18 @@ impl Thread {
         unsafe {
             let mut set: libc::cpu_set_t = std::mem::zeroed();
 
-            // Seed the mask from the thread's current allowed set. Under a
-            // cpuset cgroup this is the container's cpuset.cpus, i.e. the cores
-            // that belong to this workload. Using every online CPU here would
-            // let workers spill onto CPUs reserved for other workloads (other
+            // Seed the mask from the cpuset of this workload. Under a cpuset
+            // cgroup that is the container's cpuset.cpus, i.e. the cores that
+            // belong to this workload. Using every online CPU here would let
+            // workers spill onto CPUs reserved for other workloads (other
             // Guaranteed pods' dedicatedCpus, foreign isolcpus), which the
             // kernel then never migrates them off.
-            if libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut set) != 0 {
+            //
+            // The thread's own allowed set cannot stand in for the cpuset: the
+            // caller may be a reactor thread, which EAL has pinned to a single
+            // core, and a mask seeded from that collapses to nothing once the
+            // reactor cores are cleared.
+            if !Self::cgroup_cpuset(&mut set) {
                 // Fallback: all online CPUs.
                 for i in 0..libc::sysconf(libc::_SC_NPROCESSORS_ONLN) {
                     libc::CPU_SET(i as usize, &mut set);
@@ -328,6 +333,73 @@ impl Thread {
 
             libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &set);
         }
+    }
+
+    /// Fills the set with the effective cpuset of this workload, as seen
+    /// through the cgroup. Returns false when it cannot be determined.
+    fn cgroup_cpuset(set: &mut libc::cpu_set_t) -> bool {
+        match Self::cgroup_cpuset_list() {
+            None => false,
+            Some(list) => Self::cpuset_from_list(&list, set),
+        }
+    }
+
+    /// Fills the set from a cpuset cpu list ("0-3,8,10-11"). Returns false if
+    /// the list is empty or cannot be parsed, leaving the set untrusted.
+    fn cpuset_from_list(list: &str, set: &mut libc::cpu_set_t) -> bool {
+        let mut found = false;
+        for range in list.trim().split(',').filter(|r| !r.is_empty()) {
+            let (first, last) = match range.split_once('-') {
+                None => (range, range),
+                Some((first, last)) => (first, last),
+            };
+            let (Ok(first), Ok(last)) = (first.parse::<usize>(), last.parse::<usize>()) else {
+                return false;
+            };
+            for cpu in first..=last {
+                if cpu < 8 * std::mem::size_of::<libc::cpu_set_t>() {
+                    unsafe { libc::CPU_SET(cpu, set) };
+                    found = true;
+                }
+            }
+        }
+        found
+    }
+
+    /// Reads the cpu list of this workload's cpuset, trying the cgroup v2 and
+    /// then the v1 layout, and finally the v2 root.
+    fn cgroup_cpuset_list() -> Option<String> {
+        let self_cgroup = std::fs::read_to_string("/proc/self/cgroup").unwrap_or_default();
+        let mut v2_path = None;
+        let mut v1_path = None;
+        for line in self_cgroup.lines() {
+            // hierarchy-id:controller-list:cgroup-path
+            let mut fields = line.split(':');
+            let (Some(id), Some(controllers), Some(path)) =
+                (fields.next(), fields.next(), fields.next())
+            else {
+                continue;
+            };
+            if id == "0" && controllers.is_empty() {
+                v2_path = Some(path.to_string());
+            } else if controllers.split(',').any(|c| c == "cpuset") {
+                v1_path = Some(path.to_string());
+            }
+        }
+
+        let mut candidates = Vec::new();
+        if let Some(path) = &v2_path {
+            candidates.push(format!("/sys/fs/cgroup{path}/cpuset.cpus.effective"));
+        }
+        if let Some(path) = &v1_path {
+            candidates.push(format!("/sys/fs/cgroup/cpuset{path}/cpuset.effective_cpus"));
+        }
+        candidates.push("/sys/fs/cgroup/cpuset.cpus.effective".to_string());
+
+        candidates.into_iter().find_map(|path| {
+            let list = std::fs::read_to_string(&path).ok()?;
+            (!list.trim().is_empty()).then_some(list)
+        })
     }
 
     /// TODO
@@ -515,6 +587,46 @@ impl CurrentThreadGuard {
     pub fn new() -> Self {
         Self {
             previous: Thread::current(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cpus(list: &str) -> Option<Vec<usize>> {
+        let mut set: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        if !Thread::cpuset_from_list(list, &mut set) {
+            return None;
+        }
+        Some(
+            (0..16)
+                .filter(|cpu| unsafe { libc::CPU_ISSET(*cpu, &set) })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn cpuset_list_parsing() {
+        assert_eq!(cpus("3"), Some(vec![3]));
+        assert_eq!(cpus("0-3"), Some(vec![0, 1, 2, 3]));
+        assert_eq!(cpus("0-1,4,6-7"), Some(vec![0, 1, 4, 6, 7]));
+        assert_eq!(cpus("2\n"), Some(vec![2]));
+        // an unusable list must be reported, not silently taken as empty
+        assert_eq!(cpus(""), None);
+        assert_eq!(cpus("  \n"), None);
+        assert_eq!(cpus("a-b"), None);
+        assert_eq!(cpus("0-"), None);
+    }
+
+    #[test]
+    fn cgroup_cpuset_is_readable() {
+        let mut set: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        // Must not panic wherever it runs; when a cpuset is exposed the set it
+        // reports has to be non-empty.
+        if Thread::cgroup_cpuset(&mut set) {
+            assert!(unsafe { libc::CPU_COUNT(&set) } > 0);
         }
     }
 }


### PR DESCRIPTION
Found while testing unrelated LVM work on a branch that advances the spdk-rs pin:
io-engine's `reactor_start_stop` failed, and it turned out to be nothing to do with the
LVM changes.

## What this keeps

PR #115 confined off reactor workers to the cores assigned to this workload rather than
to every online CPU, so that workers cannot spill onto CPUs reserved for other workloads
(other Guaranteed pods' dedicatedCpus, foreign isolcpus). That intent is preserved here.
This is not a revert: the mask is still confined to the workload's cpuset. It just reads
the cpuset from the cgroup instead of inferring it from the calling thread.

## The problem

`unaffinitize_tid` seeds the mask with `sched_getaffinity` on the calling thread:

```rust
if libc::sched_getaffinity(tid, size_of::<cpu_set_t>(), &mut set) != 0 { ... }
```

`sched_getaffinity` returns the cpuset intersected with any explicit pinning, so it only
equals the cpuset while nobody has pinned the thread. EAL pins reactor threads, and
`spawn_unaffinitized` threads inherit the affinity of whoever spawned them. When the
spawner is a reactor thread the seed is a single CPU, clearing the reactor cores empties
the mask, and the empty set guard then restores the original set, pinning the worker onto
the very reactor core the function exists to keep it off.

Measured on a 32 core host, engine started with `-l 0,1`:

```
/proc/<pid>/status        Cpus_allowed_list: 0     <- the seed the code reads
/sys/fs/cgroup/cpuset.cpus.effective  0-31         <- the cpuset it means to read
```

The divergence is reproducible without SPDK at all: a process under `taskset -c 0`
reports `Cpus_allowed_list: 0` while its cgroup cpuset still reports `0-31`.

Because the inherited mask depends on whether a thread was created before or after EAL
pinned the main thread, the effect is order dependent. On the same run, some workers
landed correctly and others landed on a reactor core:

```
tid comm              cpus
--- ----------------- -----
    io-engine         0      <- main thread, EAL pinned, expected
    dpdk-worker1      1      <- reactor core, expected
    io-engine         2-31   <- off reactor, correct
    io-engine         0      <- worker pinned onto reactor core 0
```

The cpuset monitor path added by #115 is not affected, because a thread whose mask the
kernel has just reset to the cpuset reads back the cpuset. It is the
`spawn_unaffinitized` path that collapses.

## The fix

Read the effective cpuset from the cgroup: the v2 layout
(`/sys/fs/cgroup<path>/cpuset.cpus.effective`), then the v1 layout
(`/sys/fs/cgroup/cpuset<path>/cpuset.effective_cpus`), then the v2 root. Fall back to all
online CPUs only when no cpuset is exposed. Clearing the reactor cores and the empty set
guard are unchanged, so a cpuset made up only of reactor cores still behaves as before.

## Why it matters beyond the test

The tokio runtime is created through `Mthread::spawn_unaffinitized`, so on a node whose
engine is pinned to few cores the runtime threads, and the blocking work they carry, can
be pinned onto the polling core.

Same engine and `-l 0,1`, on a 10 core machine, after the change:

```
tid comm              cpus
--- ----------------- -----
    io-engine         0      <- main thread, EAL pinned, expected
    dpdk-worker1      1      <- reactor core, expected
    io-engine         2-9
    io-engine         2-9
    tokio-runtime-w   2-9
    tokio-runtime-w   2-9
    tokio-runtime-w   2-9
    tokio-runtime-w   2-9
```

Every non reactor thread is off the reactor cores, including all of the tokio workers.

## It also unblocks pin bumps

io-engine's `reactor_start_stop` asserts that an unaffinitized thread does not run on a
reactor core:

```rust
assert!(cpu as u32 > Cores::last().id())
```

With a `0x3` reactor mask the worker lands on cpu 0 and `0 > 1` is false, so the test
fails deterministically. openebs/mayastor develop still pins spdk-rs `ece88be`, which
predates #115, so this has not shown up in mayastor CI yet; it fails for anyone
advancing their pin. Verified fail to pass with this change:

```
test reactor_start_stop ... ok
test result: ok. 1 passed; 0 failed
```

## Testing

- unit tests for the cpu list parsing: single cpu, ranges, mixed lists, trailing
  newline, and the unusable inputs that must be reported rather than treated as an
  empty set
- `cargo fmt` and `cargo clippy` clean via `scripts/rust-style.sh` and
  `scripts/rust-linter.sh`
- the affinity measurements above, before and after, on a 32 core host and a 10 core VM
- io-engine's full `scripts/cargo-test.sh` in a VM with enough hugepages to host the
  container based tests, to confirm nothing else moved
