### PR TITLE
feat(bdev): support asynchronous bdev destruction

### DIFF
--- a/src/bdev.rs
+++ b/src/bdev.rs
@@ -19,7 +19,7 @@ use crate::{
         spdk_bdev_module_release_bdev, spdk_bdev_register, spdk_bdev_unregister,
         vbdev_crypto_disk_get_base_bdev, SPDK_BDEV_CLAIM_EXCL_WRITE, SPDK_BDEV_CLAIM_NONE,
     },
-    BdevIo, BdevModule, BdevOps, IoChannel, IoDevice, IoType, Thread, Uuid,
+    BdevDestructCompletion, BdevIo, BdevModule, BdevOps, IoChannel, IoDevice, IoType, Thread, Uuid,
 };
 
 /// Wrapper for SPDK `spdk_bdev` structure and the related API.
@@ -46,6 +46,31 @@ impl<BdevData> Bdev<BdevData>
 where
     BdevData: BdevOps,
 {
+    /// Returns an action that completes asynchronous SPDK bdev destruction.
+    ///
+    /// # Safety
+    ///
+    /// The returned [`BdevDestructCompletion`] captures a raw pointer to the underlying
+    /// `spdk_bdev` together with a function that frees the owning container.
+    /// It must be completed exactly once, from the I/O device unregister callback
+    ///  (i.e. after every I/O channel has been torn down)
+    /// of a bdev whose `destruct()` returned `BdevDestruct::Async`. Completing it more
+    /// than once, or while the bdev is still in use, is a use-after-free.
+    pub unsafe fn async_destruct_completion(&self) -> BdevDestructCompletion {
+        unsafe fn drop_container<BdevData>(context: *mut c_void)
+        where
+            BdevData: BdevOps,
+        {
+            drop(Box::from_raw(context as *mut Container<BdevData>));
+        }
+
+        BdevDestructCompletion {
+            bdev: self.as_inner_ptr(),
+            context: self.as_inner_ptr().cast(),
+            drop_context: drop_container::<BdevData>,
+        }
+    }
+
     /// Registers this Bdev in SPDK.
     /// TODO: comment
     /// TODO: Error / result
@@ -406,11 +431,7 @@ where
     BdevData: BdevOps,
 {
     fn drop(&mut self) {
-        // Tell the Bdev data object to be cleaned up.
-        let pinned_data = unsafe { Pin::new_unchecked(&mut self.data) };
-        pinned_data.destruct();
-
-        // Drop the associated strings.
+        // Drop the associated strings after SPDK destruction is complete.
         unsafe {
             CString::from_raw(self.bdev.name);
             CString::from_raw(self.bdev.product_name);

--- a/src/bdev_builder.rs
+++ b/src/bdev_builder.rs
@@ -8,7 +8,8 @@ use crate::{
         spdk_bdev_io, spdk_bdev_io_type, spdk_get_io_channel, spdk_io_channel, spdk_json_write_ctx,
         SPDK_BDEV_RESET_IO_DRAIN_RECOMMENDED_VALUE,
     },
-    Bdev, BdevIo, BdevModule, BdevOps, IoChannel, IoDevice, IoType, JsonWriteContext, Uuid,
+    Bdev, BdevDestruct, BdevIo, BdevModule, BdevOps, IoChannel, IoDevice, IoType, JsonWriteContext,
+    Uuid,
 };
 
 /// Builder for `Bdev` structure.
@@ -249,10 +250,18 @@ unsafe extern "C" fn inner_bdev_destruct<BdevData>(ctx: *mut c_void) -> i32
 where
     BdevData: BdevOps,
 {
-    // Dropping the container will drop all the associated resources:
-    // the context, names, function table and `spdk_bdev` itself.
-    Box::from_raw(ctx as *mut Container<BdevData>);
-    0
+    let container = &mut *(ctx as *mut Container<BdevData>);
+    let data = std::pin::Pin::new_unchecked(&mut container.data);
+
+    match data.destruct() {
+        BdevDestruct::Sync => {
+            // Dropping the container frees the context, names, function table
+            // and `spdk_bdev` after synchronous destruction has completed.
+            drop(Box::from_raw(ctx as *mut Container<BdevData>));
+            0
+        }
+        BdevDestruct::Async => 1,
+    }
 }
 
 /// TODO

--- a/src/bdev_ops.rs
+++ b/src/bdev_ops.rs
@@ -1,6 +1,23 @@
-///! TODO
+//! TODO
 use crate::{BdevIo, IoChannel, IoDevice, IoType, JsonWriteContext};
-use std::pin::Pin;
+use std::{os::raw::c_void, pin::Pin};
+
+/// Describes whether a bdev destructor has completed in-line or if we need to
+/// await for the I/O device unregister callback.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BdevDestruct {
+    /// Destruction completed synchronously.
+    Sync,
+    /// Destruction will complete through an I/O-device unregister callback.
+    Async,
+}
+
+/// Deferred completion of an asynchronous bdev destruction.
+pub struct BdevDestructCompletion {
+    pub(crate) bdev: *mut crate::libspdk::spdk_bdev,
+    pub(crate) context: *mut c_void,
+    pub(crate) drop_context: unsafe fn(*mut c_void),
+}
 
 /// TODO
 pub trait BdevOps {
@@ -14,7 +31,7 @@ pub trait BdevOps {
     type IoDev: IoDevice;
 
     /// TODO
-    fn destruct(self: Pin<&mut Self>);
+    fn destruct(self: Pin<&mut Self>) -> BdevDestruct;
 
     /// TODO
     ///

--- a/src/io_devices.rs
+++ b/src/io_devices.rs
@@ -7,7 +7,8 @@ use std::{pin::Pin, ptr::NonNull};
 
 use crate::{
     ffihelper::IntoCString,
-    libspdk::{spdk_io_device_register, spdk_io_device_unregister},
+    libspdk::{spdk_bdev_destruct_done, spdk_io_device_register, spdk_io_device_unregister},
+    BdevDestructCompletion,
 };
 
 /// Abstraction over SPDK concept of I/O device.
@@ -16,10 +17,11 @@ pub trait IoDevice: Sized {
     /// device.
     type ChannelData;
 
-    /// Called during device unregisration process to allow the client code
-    /// to do a clean up.
-    /// The default implementation does nothing.
-    fn unregister_callback(&self) {}
+    /// Called after all I/O channels have been destroyed during device
+    /// unregistration. The default implementation performs no action.
+    fn unregister_callback(self: Pin<&mut Self>) -> Option<BdevDestructCompletion> {
+        None
+    }
 
     /// Called to create a new per-core I/O channel data instance.
     fn io_channel_create(self: Pin<&mut Self>) -> Self::ChannelData;
@@ -145,5 +147,10 @@ unsafe extern "C" fn inner_io_device_unregister_cb<Dev>(ctx: *mut c_void)
 where
     Dev: IoDevice,
 {
-    from_io_device_id::<Dev>(ctx).unregister_callback();
+    let completion = from_io_device_id::<Dev>(ctx).unregister_callback();
+
+    if let Some(completion) = completion {
+        spdk_bdev_destruct_done(completion.bdev, 0);
+        (completion.drop_context)(completion.context);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::{
         BdevModule, BdevModuleBuild, BdevModuleBuilder, WithModuleConfigJson, WithModuleFini,
         WithModuleGetCtxSize, WithModuleInit,
     },
-    bdev_ops::BdevOps,
+    bdev_ops::{BdevDestruct, BdevDestructCompletion, BdevOps},
     cpu_cores::{Core, CoreIterator, Cores, RoundRobinCoreSelector},
     dma::{DmaBuf, DmaError},
     error::{spdk_error, SpdkError, SpdkResult},

--- a/src/untyped_bdev.rs
+++ b/src/untyped_bdev.rs
@@ -1,5 +1,5 @@
 ///! Definition of untyped Bdev alias and related types.
-use crate::{Bdev, BdevIo, BdevOps, IoChannel, IoDevice, IoType};
+use crate::{Bdev, BdevDestruct, BdevIo, BdevOps, IoChannel, IoDevice, IoType};
 use std::pin::Pin;
 
 /// An alias for a Bdev whose type is unknown or not important.
@@ -12,7 +12,9 @@ impl BdevOps for () {
     type BdevData = ();
     type IoDev = ();
 
-    fn destruct(self: Pin<&mut Self>) {}
+    fn destruct(self: Pin<&mut Self>) -> BdevDestruct {
+        BdevDestruct::Sync
+    }
 
     fn submit_request(&self, _chan: IoChannel<Self::ChannelData>, _bio: BdevIo<Self::BdevData>) {
         unreachable!()


### PR DESCRIPTION
Previously a Bdev's `destruct()` was invoked from the container's `Drop` impl and always completed synchronously, with SPDK's `destruct` callback unconditionally freeing the container and returning 0. This is unsound for any bdev that registers an I/O device: `spdk_io_device_unregister` defers its final callback until after all I/O channels are torn down, so freeing the container (which co-allocates the `spdk_bdev` and the io_device) during `destruct` leaves that deferred callback dereferencing freed memory.

Make destruction able to complete asynchronously:

- `BdevOps::destruct()` now returns a `BdevDestruct { Sync, Async }`, mirroring SPDK's destruct return contract (0 = done, 1 = pending).
- `inner_bdev_destruct` calls `data.destruct()` and, for `Sync`, drops the container and returns 0; for `Async` returns 1 and frees nothing, deferring teardown to the I/O device unregister callback.
- `IoDevice::unregister_callback` now returns an optional `BdevDestructCompletion`; when present, the unregister callback calls `spdk_bdev_destruct_done` and then frees the container exactly once.
- Add `Bdev::async_destruct_completion()` (unsafe) to build that completion token from the owning container.
- Remove the `destruct()` call from `Container::drop`, which now only releases the associated C strings.

The `()` untyped-bdev dummy impl returns `Sync` since it registers no I/O device and cannot defer completion.